### PR TITLE
Added @rclnodejs scope to package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ref-napi
 ========
+*THIS PACKAGE WAS FORKED FROM http://github.com/node-ffi-napi/ref-napi AND UPDATED TO 
+ENABLE rclnodejs TO RUN UNDER NODE VERSIONS 12-16. NO TESTING BEYOND the rclnodejs TEST SUITE
+HAS BEEN PERFORMED. USE AT YOUR OWN DISCRETION.*
 ### Turn Buffer instances into "pointers"
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/node-ffi-napi/ref-napi.svg)](https://greenkeeper.io/)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ref-napi",
+  "name": "@rclnodejs/ref-napi",
   "description": "Turn Buffer instances into \"pointers\"",
   "engines": {
     "node": ">= 10.0"
@@ -26,7 +26,7 @@
   "author": "Anna Henningsen <anna@addaleax.net>",
   "repository": {
     "type": "git",
-    "url": "git://github.com/node-ffi-napi/ref-napi.git"
+    "url": "git://github.com/rclnodejs/ref-napi.git"
   },
   "main": "./lib/ref.js",
   "scripts": {


### PR DESCRIPTION
Convert package to a scoped package under the @rclnodejs scope name. As a scoped package it will be less likely to be used for general purposes.