### PR TITLE
Setup build matrix for node 10, 12, 14, 16 on linux & osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 
+dist: bionic
+
 env:
   - CXX=g++-4.9
   - CXX=clang++
@@ -23,6 +25,7 @@ node_js:
   - "10"
   - "12"
   - "14"
+  - "16"
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,9 @@ addons:
 language: node_js
 
 node_js:
+  - "10"
+  - "12"
   - "14"
-  - "15"
   - "16"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,63 +2,20 @@ sudo: false
 
 dist: bionic
 
-env:
-  - CXX=g++-4.9
-  - CXX=clang++
-
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - g++-4.9
+      - g++
 
 language: node_js
 
-os:
-  - linux
-  - osx
-
-osx_image: xcode10
-
 node_js:
-  - "10"
-  - "12"
   - "14"
+  - "15"
   - "16"
-
-jobs:
-  include:
-      - os: linux
-        arch: arm64
-        node_js: 12
-        env: CXX=g++-4.9
-  exclude:
-      - os: osx
-        env: CXX=g++-4.9
-      - os: linux
-        env: CXX=clang++
-
-install:
-  - npm install --build-from-source
 
 after_success:
   - npm install coveralls
   - nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls
-
-before_deploy:
-  - ARCHIVE_NAME="${TRAVIS_TAG:-latest}-$TRAVIS_OS_NAME-`uname -m`.tar"
-  - npm run prebuild --v8_enable_pointer_compression=false --v8_enable_31bit_smis_on_64bit_arch=false
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ARCH=ia32 npm run prebuild --v8_enable_pointer_compression=false --v8_enable_31bit_smis_on_64bit_arch=false; fi
-  - tar --create --verbose --file="$ARCHIVE_NAME" --directory "$TRAVIS_BUILD_DIR/prebuilds" .
-
-deploy:
-  provider: releases
-  draft: false
-  prerelease: true
-  file: "$ARCHIVE_NAME"
-  skip_cleanup: true
-  on:
-    tags: true
-    node: 12
-  api_key: $PREBUILD_GITHUB_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ sudo: false
 
 dist: bionic
 
+os:
+  - linux
+  - osx
+
+osx_image: xcode12
+
 addons:
   apt:
     sources:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
     - nodejs_version: "10"
     - nodejs_version: "12"
     - nodejs_version: "14"
+    - nodejs_version: "16"
 
 platform:
   - x86


### PR DESCRIPTION
This PR updates the build spec for simple linux and osx across node 10.23, 12, 14 & 16. 
It does not use the previous deployment rules for prebuilts. This will be revisited asap.